### PR TITLE
Fix data size macro list for SAMD21

### DIFF
--- a/Adafruit_ZeroI2S.cpp
+++ b/Adafruit_ZeroI2S.cpp
@@ -268,16 +268,16 @@ bool Adafruit_ZeroI2S::begin(I2SSlotSize width, int fs_freq, int mck_mult)
 	uint8_t wordSize;
 	switch(width){
 		case I2S_8_BIT:
-			wordSize = I2S_SERCTRL_DATASIZE_8;
+			wordSize = I2S_SERCTRL_DATASIZE_8_Val;
 			break;
 		case I2S_16_BIT:
-			wordSize = I2S_SERCTRL_DATASIZE_16;
+			wordSize = I2S_SERCTRL_DATASIZE_16_Val;
 			break;
 		case I2S_24_BIT:
-			wordSize = I2S_SERCTRL_DATASIZE_24;
+			wordSize = I2S_SERCTRL_DATASIZE_24_Val;
 			break;
 		case I2S_32_BIT:
-			wordSize = I2S_SERCTRL_DATASIZE_32;
+			wordSize = I2S_SERCTRL_DATASIZE_32_Val;
 			break;
 		default:
 			DEBUG_PRINTLN("invalid width!");


### PR DESCRIPTION
Specifying I2S data size worked on SAMD51 but not on SAMD21. All data size selections on SAMD21 would result in 32-bit data. The wrong macros were being fed into the `I2S_SERCTRL_DATASIZE(value)` macro in the SERCTRL config setting, for example `I2S_SERCTRL_DATASIZE_16` instead of `I2S_SERCTRL_DATASIZE_16_Val`. You can either use `I2S_SERCTRL_DATASIZE_16` directly, or call `I2S_SERCTRL_DATASIZE(I2S_SERCTRL_DATASIZE_16_Val)` but `I2S_SERCTRL_DATASIZE(I2S_SERCTRL_DATASIZE_16)` will end up setting the DATASIZE section of the config register to zero (forcing 32 bits).

The fix here is extremely simple and merely makes the SAMD21 config selection method match the SAMD51 method.