### PR TITLE
BUGFIX: check for -1 on tx

### DIFF
--- a/Adafruit_ZeroI2S.cpp
+++ b/Adafruit_ZeroI2S.cpp
@@ -77,7 +77,7 @@ bool Adafruit_ZeroI2S::begin(I2SSlotSize width, int fs_freq, int mck_mult) {
 
   pinPeripheral(_fs, PIO_I2S);
   pinPeripheral(_sck, PIO_I2S);
-  pinPeripheral(_rx, PIO_I2S);
+  if(_rx != -1) pinPeripheral(_rx, PIO_I2S);
   pinPeripheral(_tx, PIO_I2S);
 
   I2S->CTRLA.bit.ENABLE = 0;


### PR DESCRIPTION
This is a one line change that fixes a bug I noticed. I have a hybrid SAMD51 device that does not have I2S input. The local variable _rx was set to -1 but when passed to the pinPeripheral function it turns into an unsigned integer and messes things up. I added a conditional check to the Adafruit_ZeroI2S::begin function to not initialize pinPeriperhal is _rx is -1.  The notion of setting _rx to -1 in order to disable input came from line 61 of the alternate constructor.

This fix allows me to play audio, where before the sound output was not functioning at all.